### PR TITLE
ADD executable permission for the script inside the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,6 @@ ARG REDIS_VERSION=6.2.6
 FROM redis:${REDIS_VERSION}-alpine
 
 COPY start-redis-server.sh /usr/bin/start-redis-server.sh
+RUN chmod +x /usr/bin/start-redis-server.sh
 
 CMD ["/usr/bin/start-redis-server.sh"]


### PR DESCRIPTION
Issue:

Docker run error
2024-04-12 09:59:27 /usr/local/bin/docker-entrypoint.sh: exec: line 16: /usr/bin/start-redis-server.sh: Permission denied

Solution:
Added executable permission for the script inside the container

chmod +x: Added Linux command to change the permissions of a file. 
The +x option adds the executable permission to the file.